### PR TITLE
fix: fixed active days count start

### DIFF
--- a/active_days.py
+++ b/active_days.py
@@ -13,7 +13,7 @@ def active_days(file_path):
             if(date not in days):
                 days[date] = {
                     "date": date,
-                    "count": 0
+                    "count": 1
                 }
             else:
                 days[date]["count"] += 1


### PR DESCRIPTION
Fixed active days counter so it starts at 1 instead of 0