### PR TITLE
fix: fixed top_hashtags counter

### DIFF
--- a/top_hashtags.py
+++ b/top_hashtags.py
@@ -16,7 +16,7 @@ def top_hashtags(file_path):
                     if(hashtag not in hashtags):
                         hashtags[hashtag] = {
                             "hashtag": hashtag,
-                            "count": 0
+                            "count": 1
                         }
                     else:
                         hashtags[hashtag]["count"] += 1


### PR DESCRIPTION
Fixed top_hashtags counter so it starts at 1 instead of 0